### PR TITLE
CORCI-960 build: Update MACSio to build an openmpi3 package

### DIFF
--- a/MACSio.spec
+++ b/MACSio.spec
@@ -72,10 +72,6 @@ BuildRequires: mpich-devel%{?_isa}
 
 %description mpich
 MACSio for MPICH
-$endif
-
-%description mpich
-MACSio for MPICH
 %endif
 
 %if %{with_openmpi3}

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -86,6 +86,11 @@ MACSio for OpenMPI3
 
 %prep
 %setup -q
+for mpi in %{?mpi_list}
+do
+  mkdir $mpi
+  cp -Rs * $mpi/
+done
 
 %build
 for mpi in %{?mpi_list}

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -9,7 +9,12 @@
 %endif
 
 %if (0%{?suse_version} >= 1500)
-%global module_load() if [ "%{1}" == "openmpi3" ]; then module load gnu-openmpi; else module load gnu-%{1}; fi
+%global module_load() \
+  if [ "%{1}" == "openmpi3" ]; then \
+    module load gnu-openmpi; \
+  else \
+    module load gnu-%{1}; \
+  fi
 %else
 %global module_load() module load mpi/%{1}-%{_arch}
 %endif
@@ -31,27 +36,8 @@ BuildRequires: gcc, gcc-c++
 BuildRequires: cmake
 BuildRequires: json-cwx
 BuildRequires: hdf5-devel%{?_isa}
+
 Requires: json-cwx
-
-%if %{with_mpich}
-%package mpich
-Summary: A Multi-purpose, Application-Centric, Scalable I/O Proxy Application for MPICH
-BuildRequires: hdf5-mpich-devel%{?_isa}
-BuildRequires: mpich-devel%{?_isa}
-
-%description mpich
-MACSio for MPICH
-%endif
-
-%if %{with_openmpi3}
-%package openmpi3
-Summary: A Multi-purpose, Application-Centric, Scalable I/O Proxy Application for OpenMPI3
-BuildRequires: hdf5-openmpi3-devel%{?_isa}
-BuildRequires: openmpi3-devel%{?_isa}
-
-%description openmpi3
-MACSio for OpenMPI3
-%endif
 
 %description
 MACSio is being developed to fill a long existing void in co-design proxy
@@ -77,6 +63,30 @@ with the same set of customizable data objects.
 We hope MACSio helps to put the MAX in scalable I/O performance ;)
 
 The name "MACSio" is pronounced max-eee-oh.
+
+%if %{with_mpich}
+%package mpich
+Summary: A Multi-purpose, Application-Centric, Scalable I/O Proxy Application for MPICH
+BuildRequires: hdf5-mpich-devel%{?_isa}
+BuildRequires: mpich-devel%{?_isa}
+
+%description mpich
+MACSio for MPICH
+$endif
+
+%description mpich
+MACSio for MPICH
+%endif
+
+%if %{with_openmpi3}
+%package openmpi3
+Summary: A Multi-purpose, Application-Centric, Scalable I/O Proxy Application for OpenMPI3
+BuildRequires: hdf5-openmpi3-devel%{?_isa}
+BuildRequires: openmpi3-devel%{?_isa}
+
+%description openmpi3
+MACSio for OpenMPI3
+%endif
 
 %prep
 %setup -q
@@ -109,12 +119,11 @@ do
 done
 
 %files
-%if %{with_mpich}
 %license LICENSE
+%if %{with_mpich}
 %{_bindir}/mpich/*
 %endif
 %if %{with_openmpi3}
-%license LICENSE
 %{_bindir}/openmpi3/*
 %endif
 

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -124,7 +124,7 @@ done
 %endif
 
 %changelog
-* Wed Jul 23 2020 Phil Henderson <phillip.henderson@intel.com> - 1.1-2
+* Thu Jul 23 2020 Phil Henderson <phillip.henderson@intel.com> - 1.1-2
 - Renamed existing package to MACSio-mpich and added the MACSio-openmpi3 package
 
 * Wed Jun 24 2020 Phil Henderson <phillip.henderson@intel.com> - 1.1-1

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -93,7 +93,7 @@ do
   mkdir $mpi
   pushd $mpi
   %module_load $mpi
-  cmake -DCMAKE_INSTALL_PREFIX=%{_libdir}/$mpi \
+  cmake -DCMAKE_INSTALL_PREFIX=%{_libdir}/$mpi/bin \
     -DWITH_JSON-CWX_PREFIX=%{prefix} \
     -DENABLE_SILO_PLUGIN=OFF \
     -DENABLE_HDF5_PLUGIN=ON \
@@ -116,11 +116,11 @@ done
 %license LICENSE
 %if %{with_mpich}
 %files mpich
-%{_libdir}/mpich/*
+%{_libdir}/mpich/bin/*
 %endif
 %if %{with_openmpi3}
 %files openmpi3
-%{_libdir}/openmpi3/*
+%{_libdir}/openmpi3/bin/*
 %endif
 
 %changelog

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -93,13 +93,13 @@ do
   mkdir $mpi
   pushd $mpi
   %module_load $mpi
-  cmake -DCMAKE_INSTALL_PREFIX=%{_bindir}/$mpi \
-    -DWITH_JSON-CWX_PREFIX=%{_usr} \
+  cmake -DCMAKE_INSTALL_PREFIX=%{_libdir}/$mpi \
+    -DWITH_JSON-CWX_PREFIX=%{prefix} \
     -DENABLE_SILO_PLUGIN=OFF \
     -DENABLE_HDF5_PLUGIN=ON \
     -DWITH_HDF5_PREFIX=%{_libdir}/$mpi \
     ..
-  make
+  %{make_build}
   module purge
   popd
 done
@@ -116,11 +116,11 @@ done
 %license LICENSE
 %if %{with_mpich}
 %files mpich
-%{_bindir}/mpich/*
+%{_libdir}/mpich/*
 %endif
 %if %{with_openmpi3}
 %files openmpi3
-%{_bindir}/openmpi3/*
+%{_libdir}/openmpi3/*
 %endif
 
 %changelog

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -9,12 +9,7 @@
 %endif
 
 %if (0%{?suse_version} >= 1500)
-%global module_load() \
-  if [ "%{1}" == "openmpi3" ]; then \
-    module load gnu-openmpi; \
-  else \
-    module load gnu-%{1}; \
-  fi
+%global module_load() if [ "%{1}" == "openmpi3" ]; then module load gnu-openmpi; else module load gnu-%{1}; fi
 %else
 %global module_load() module load mpi/%{1}-%{_arch}
 %endif

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -85,6 +85,9 @@ MACSio for OpenMPI 3
 %setup -q
 
 %build
+%if (0%{?suse_version} >= 1500)
+  sed -i -e s/H5pubconf.h/H5pubconf-64.h/ plugins/macsio_hdf5.c
+%endif
 for mpi in %{?mpi_list}
 do
   mkdir $mpi
@@ -96,9 +99,6 @@ do
     -DENABLE_HDF5_PLUGIN=ON \
     -DWITH_HDF5_PREFIX=%{_libdir}/$mpi \
     ..
-  %if (0%{?suse_version} >= 1500)
-    sed -i -e s/H5pubconf.h/H5pubconf-64.h/ plugins/macsio_hdf5.c
-  %endif
   make
   module purge
   popd

--- a/MACSio.spec
+++ b/MACSio.spec
@@ -89,7 +89,7 @@ MACSio for OpenMPI3
 for mpi in %{?mpi_list}
 do
   mkdir $mpi
-  cp -Rs * $mpi/
+  cp -s * $mpi/
 done
 
 %build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NAME      := MACSio
 SRC_EXT   := gz
+TEST_PACKAGES := $(NAME) $(NAME)-mpich $(NAME)-openmpi3
 
 include packaging/Makefile_packaging.mk

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -1,5 +1,5 @@
 # Common Makefile for including
-# Needs the following variables set at a minium:
+# Needs the following variables set at a minimum:
 # NAME :=
 # SRC_EXT :=
 
@@ -23,10 +23,11 @@ RPM_BUILD_OPTIONS += $(EXTERNAL_RPM_BUILD_OPTIONS)
 BUILD_OS ?= leap.15
 PACKAGING_CHECK_DIR ?= ../packaging
 LOCAL_REPOS ?= true
+TEST_PACKAGES ?= ${NAME}
 
-PR_REPOS         := $(shell set -x; git show -s --format=%B | sed -ne 's/^PR-repos: *\(.*\)/\1/p')
-LEAP_15_PR_REPOS := $(shell set -x; git show -s --format=%B | sed -ne 's/^PR-repos-leap15: *\(.*\)/\1/p')
-EL_7_PR_REPOS    := $(shell set -x; git show -s --format=%B | sed -ne 's/^PR-repos-el7: *\(.*\)/\1/p')
+PR_REPOS         := $(shell git show -s --format=%B | sed -ne 's/^PR-repos: *\(.*\)/\1/p')
+LEAP_15_PR_REPOS := $(shell git show -s --format=%B | sed -ne 's/^PR-repos-leap15: *\(.*\)/\1/p')
+EL_7_PR_REPOS    := $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el7: *\(.*\)/\1/p')
 COMMON_RPM_ARGS  := --define "%_topdir $$PWD/_topdir" $(BUILD_DEFINES)
 SPEC             := $(shell if [ -f $(NAME)-$(DISTRO_BASE).spec ]; then echo $(NAME)-$(DISTRO_BASE).spec; else echo $(NAME).spec; fi)
 VERSION           = $(eval VERSION := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p'))$(VERSION)
@@ -39,7 +40,7 @@ RPMS              = $(eval RPMS := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86
 DEB_TOP          := _topdir/BUILD
 DEB_BUILD        := $(DEB_TOP)/$(NAME)-$(DEB_VERS)
 DEB_TARBASE      := $(DEB_TOP)/$(DEB_NAME)_$(DEB_VERS)
-SOURCE           ?= $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) -S -l $(SPEC) | sed -e 2,\$$d -e 's/.*:  *//'))$(SOURCE)
+SOURCE           ?= $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) -S -l $(SPEC) | sed -e 2,\$$d -e 's/\\\#/\\\\\#/g' -e 's/.*:  *//'))$(SOURCE)
 PATCHES          ?= $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) -l $(SPEC) | sed -e 1d -e 's/.*:  *//' -e 's/.*\///'))$(PATCHES)
 SOURCES          := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES))
 ifeq ($(ID_LIKE),debian)
@@ -115,17 +116,20 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 ifeq ($(DL_VERSION),)
 DL_VERSION = $(VERSION)
 endif
+ifeq ($(DL_NAME),)
+DL_NAME = $(NAME)
+endif
 
-$(NAME)-$(DL_VERSION).tar.$(SRC_EXT).asc:
-	rm -f ./$(NAME)-*.tar.{gz,bz*,xz}.asc
+$(DL_NAME)-$(DL_VERSION).tar.$(SRC_EXT).asc:
+	rm -f ./$(DL_NAME)-*.tar.{gz,bz*,xz}.asc
 	curl -f -L -O '$(SOURCE).asc'
 
-$(NAME)-$(DL_VERSION).tar.$(SRC_EXT).sig:
-	rm -f ./$(NAME)-*.tar.{gz,bz*,xz}.sig
+$(DL_NAME)-$(DL_VERSION).tar.$(SRC_EXT).sig:
+	rm -f ./$(DL_NAME)-*.tar.{gz,bz*,xz}.sig
 	curl -f -L -O '$(SOURCE).sig'
 
-$(NAME)-$(DL_VERSION).tar.$(SRC_EXT):
-	rm -f ./$(NAME)-*.tar.{gz,bz*,xz}
+$(DL_NAME)-$(DL_VERSION).tar.$(SRC_EXT):
+	rm -f ./$(DL_NAME)-*.tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
 v$(DL_VERSION).tar.$(SRC_EXT):
@@ -391,7 +395,7 @@ endif
 test:
 	# Test the rpmbuild by installing the built RPM
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
-	yum -y install $(NAME)
+	yum -y install $(TEST_PACKAGES)
 
 show_version:
 	@echo $(VERSION)


### PR DESCRIPTION
Update the MACSio spec file to build the current package as a
macsio-mpich and add building a macsio-openmpi3 package

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>